### PR TITLE
chore: add CODEOWNERS for code-owner review enforcement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Default owners for everything in the repo.
 # Later matching patterns take precedence over earlier ones.
-* @eitanp461 @sveta-slepner
+* @eitanp461 @sveta-slepner @const-cloudinary

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owners for everything in the repo.
+# Later matching patterns take precedence over earlier ones.
+* @eitanp461 @sveta-slepner

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-cloudinary",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-cloudinary",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-cloudinary",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "The official Cloudinary n8n node - upload media, update asset tags and metadata, and more",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary
Adds a `.github/CODEOWNERS` file so the branch ruleset's "Require review from Code Owners" check has owners to enforce, strengthening protection on `master`.

## Changes
- Add `.github/CODEOWNERS` with `@eitanp461` and `@sveta-slepner` as default owners for the entire repo (single `*` rule — both listed on one line so neither overrides the other)

## Notes
- Takes effect only once merged to `master` (GitHub reads CODEOWNERS from the PR base branch) and with **Require review from Code Owners** enabled in the ruleset

🤖 Generated with [Claude Code](https://claude.com/claude-code)
