### PR TITLE
ci: require a package.json version bump on every PR

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -25,6 +25,19 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
+      # Every merge to master publishes (see release.yml), so each PR must
+      # bump package.json version or the publish step republishes the same
+      # version and confuses the n8n UI's update detection.
+      - name: Require version bump
+        run: |
+          BASE_VERSION=$(git show origin/master:package.json | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
+          HEAD_VERSION=$(node -p "require('./package.json').version")
+          if [ "$BASE_VERSION" = "$HEAD_VERSION" ]; then
+            echo "::error file=package.json::package.json version is still $HEAD_VERSION (same as master). Bump it — every merge to master is published."
+            exit 1
+          fi
+          echo "Version bump OK: $BASE_VERSION -> $HEAD_VERSION"
+
       - name: Install dependencies
         run: npm ci
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-cloudinary",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-cloudinary",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-cloudinary",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The official Cloudinary n8n node - upload media, update asset tags and metadata, and more",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary
Every merge to `master` triggers `npm publish` (release.yml), so a PR that forgets to bump `package.json` version republishes the same version and breaks the n8n UI's update detection. This adds a fail-fast gate to the PR check so forgetting is impossible.

## Changes
- Add a **Require version bump** step to `pr-check.yml` that fails early (before `npm ci`) when the PR's `package.json` version matches `origin/master`
- Bump version to `0.1.1` so this PR passes its own gate

## Related
- Addresses the review feedback on #8 (manual bump reminder) at the process level

## How to Test
- This PR's own check run: the "Require version bump" step should pass with `Version bump OK: 0.1.0 -> 0.1.1`
- Negative case: any PR leaving the version untouched will fail that step with an annotated error on `package.json`

## Notes
- From now on **every** PR needs a version bump, including docs/CI-only changes — accepted trade-off of the minimal approach
- PR #8 will need its own bump (to `0.1.2` if this merges first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
