### PR TITLE
feat: AI-generated player content + regrouped Video Player options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ The *Widget → Video Player* operation builds a [Cloudinary Video Player](https
 - **Adaptive streaming vs. format selection.** If you select an adaptive-streaming **Source Type** (HLS or MPEG-DASH), the transformation must **not** pin a delivery format (an `f_` component such as `f_auto:video`, which an *Optimize* step adds). The two are incompatible — Cloudinary can't apply a streaming profile to a fixed non-streaming format. The node detects this and fails with a clear message; for adaptive streaming, keep the transformation to resize/crop/trim only.
 - **Aspect Ratio crops on top of your Transformation.** Setting an **Aspect Ratio** makes the player re-crop the video to those proportions using the **Crop Mode** field (*Smart*, *Fill*, or *Pad* — default *Smart*). With the default *Smart* mode, that re-crop can't be combined with a Transformation that already crops the video, and the player rejects it. The node fails fast with a clear message; to render either set *Crop Mode* to *Fill* or *Pad*, or clear *Aspect Ratio* and let your Transformation define the framing.
 
+#### AI-generated content (captions, title, description, chapters)
+
+The **AI-Generated Content** options let the player generate content on demand — no caption files to author. Toggle **Generate Captions** (auto-transcript shown as toggleable captions), **Generate Title**, **Generate Description**, and/or **Generate Chapters**. The player only generates what doesn't already exist, and transcript generation needs the video's audio to contain dialogue. These options are emitted into the `player_config` (the JS `player.source()` config), not the iframe embed URL. On most accounts these are **enabled by default** under *Settings → Security → Unsigned actions allowed* — so there's nothing to switch on. See the [Video Player customization docs](https://cloudinary.com/documentation/video_player_customization).
+
+> **Translated subtitles need the Google Translate add-on.** The **Subtitle Languages** field (e.g. `es, fr-FR`) produces AI-*translated* subtitle tracks, which require the **Google Translate** add-on on your account. To enable it:
+> 1. **Register for the add-on** on the [Cloudinary Add-ons page](https://console.cloudinary.com/settings/addons) (Console → *Settings → Add-ons*) — the free tier is enough to try it.
+> 2. Allow it as an unsigned transformation: **Console → *Settings → Security*** → *Unsigned add-on transformations allowed* → enable **Google Translate**.
+>
+> Base captions (the *Generate Captions* toggle, single language) need **no** add-on — only translation into other languages does.
+
 ## Supported authentication methods
 
 - API key & API secret

--- a/nodes/Cloudinary/descriptions/widget.fields.ts
+++ b/nodes/Cloudinary/descriptions/widget.fields.ts
@@ -5,42 +5,35 @@ import { INodeProperties } from 'n8n-workflow';
 // and a self-hosted `player_config` JSON. The shared Public ID + Type identity fields
 // live in transform.fields.ts (gated on resource:['transform','widget']) so they are
 // not duplicated here.
+//
+// UI shape: a few essentials stay top-level (Transformation, Source Types); everything
+// else is grouped into purpose-named, collapsed `collection` fields — Playback,
+// Size & Layout, Appearance, AI-Generated Content, Player Features — so the form stays
+// approachable instead of a flat wall of 19 controls. n8n collections can only gate
+// their inner fields on OTHER fields in the SAME collection, so co-dependent controls
+// (Fluid→Width/Height, Aspect Ratio→Crop Mode, Generate Captions→Label/Languages) are
+// deliberately kept together. videoPlayer.ts reads each collection as one object.
+
+const SHOW = { show: { resource: ['widget'], operation: ['videoPlayer'] } };
 
 export const widgetFields: INodeProperties[] = [
+	// ── Essentials (top-level) ──────────────────────────────────────────────────
 	{
-		displayName: 'Autoplay Mode',
-		name: 'playerAutoplayMode',
-		type: 'options',
-		options: [
-			{ name: 'Never', value: '', description: 'Do not autoplay (player default)' },
-			{ name: 'Always', value: 'always', description: 'Autoplay as soon as the player loads' },
-			{ name: 'On Scroll', value: 'on-scroll', description: 'Autoplay when the player scrolls into view' },
-		],
+		displayName: 'Transformation',
+		name: 'playerTransformation',
+		type: 'string',
 		default: '',
-		description: 'When the video should start playing automatically. Most browsers require the player to be muted for autoplay to work.',
-		displayOptions: {
-			show: { resource: ['widget'], operation: ['videoPlayer'] },
-		},
+		placeholder: 'e.g. c_fill,w_640,h_360/e_blur:500',
+		description: 'Cloudinary transformation string applied to the played video stream — in both the iframe embed URL and the player_config output. Use video-capable transforms (resize/crop, trim, e_blur, e_fade, vc_, etc.). Image-only effects such as e_grayscale are silently ignored on video, so they have no visible effect here; the poster image is a separate source and is not affected by this field. See the video effects reference: https://cloudinary.com/documentation/video_effects_and_enhancements.',
+		displayOptions: SHOW,
 	},
 	{
-		displayName: 'Muted',
-		name: 'playerMuted',
-		type: 'boolean',
-		default: false,
-		description: 'Whether the player starts muted',
-		displayOptions: {
-			show: { resource: ['widget'], operation: ['videoPlayer'] },
-		},
-	},
-	{
-		displayName: 'Loop',
-		name: 'playerLoop',
-		type: 'boolean',
-		default: false,
-		description: 'Whether the video restarts from the beginning when it ends',
-		displayOptions: {
-			show: { resource: ['widget'], operation: ['videoPlayer'] },
-		},
+		displayName: 'Poster',
+		name: 'playerPoster',
+		type: 'string',
+		default: '',
+		description: 'URL of the still image shown before playback starts. Leave empty to use a frame from the video. Tip: wire in a Video: Thumbnail step\'s secure_url to use a specific frame.',
+		displayOptions: SHOW,
 	},
 	{
 		displayName: 'Source Types',
@@ -55,157 +48,62 @@ export const widgetFields: INodeProperties[] = [
 			{ name: 'WebM', value: 'webm', description: 'Progressive WebM' },
 		],
 		default: [],
-		description: 'Preferred delivery formats in fallback order. Leave empty to use the player\'s default format selection. Note: the adaptive-streaming types (HLS, MPEG-DASH) deliver via a streaming profile and cannot be combined with a Transformation that pins a format (an f_ component such as f_auto:video, e.g. from an Optimize step). For adaptive streaming, keep the transformation to resize/crop/trim only.',
-		displayOptions: {
-			show: { resource: ['widget'], operation: ['videoPlayer'] },
-		},
+		description: 'The video formats the player can request, in fallback order (the player picks the first one the viewer\'s browser supports). Leave empty to let the player choose automatically. Tip: HLS and MPEG-DASH are adaptive streaming — for the smoothest playback, pick one of those plus MP4 as a fallback. Note: HLS/MPEG-DASH cannot be combined with a Transformation that pins a format (an f_ component such as f_auto:video, e.g. from an Optimize step) — keep the Transformation to resize/crop/trim only when using them.',
+		displayOptions: SHOW,
 	},
+
+	// ── Playback ──────────────────────────────────────────────────────────────
 	{
-		displayName: 'Poster',
-		name: 'playerPoster',
-		type: 'string',
-		default: '',
-		description: 'URL of the still image shown before playback starts. Leave empty to use a frame from the video.',
-		displayOptions: {
-			show: { resource: ['widget'], operation: ['videoPlayer'] },
-		},
-	},
-	{
-		displayName: 'Transformation',
-		name: 'playerTransformation',
-		type: 'string',
-		default: '',
-		placeholder: 'c_fill,w_640,h_360/e_blur:500',
-		description: 'Cloudinary transformation string applied to the played video stream — in both the iframe embed URL and the player_config output. Use video-capable transforms (resize/crop, trim, e_blur, e_fade, vc_, etc.). Image-only effects such as e_grayscale are silently ignored on video, so they have no visible effect here; the poster image is a separate source and is not affected by this field. See the video effects reference: https://cloudinary.com/documentation/video_effects_and_enhancements.',
-		displayOptions: {
-			show: { resource: ['widget'], operation: ['videoPlayer'] },
-		},
-	},
-	{
-		displayName: 'Fluid',
-		name: 'playerFluid',
-		type: 'boolean',
-		default: false,
-		description: 'Whether the player resizes responsively to fill its container. When on, Width and Height are replaced by an aspect-ratio CSS style.',
-		displayOptions: {
-			show: { resource: ['widget'], operation: ['videoPlayer'] },
-		},
-	},
-	{
-		displayName: 'Width',
-		name: 'playerWidth',
-		type: 'number',
-		default: 0,
-		description: 'Player width in pixels. Leave 0 for the default (640 px).',
-		displayOptions: {
-			show: { resource: ['widget'], operation: ['videoPlayer'], playerFluid: [false] },
-		},
-	},
-	{
-		displayName: 'Height',
-		name: 'playerHeight',
-		type: 'number',
-		default: 0,
-		description: 'Player height in pixels. Leave 0 for the default (360 px).',
-		displayOptions: {
-			show: { resource: ['widget'], operation: ['videoPlayer'], playerFluid: [false] },
-		},
-	},
-	{
-		displayName: 'Aspect Ratio',
-		name: 'playerAspectRatio',
-		type: 'options',
-		options: [
-			{ name: '1:1', value: '1:1' },
-			{ name: '16:9', value: '16:9' },
-			{ name: '9:16', value: '9:16' },
-			{ name: 'Default', value: '' },
-		],
-		default: '',
-		description: 'Player aspect ratio. Leave unset to use the video\'s natural dimensions.',
-		displayOptions: {
-			show: { resource: ['widget'], operation: ['videoPlayer'] },
-		},
-	},
-	{
-		displayName: 'Crop Mode',
-		name: 'playerCropMode',
-		type: 'options',
-		options: [
-			{ name: 'Smart', value: 'smart', description: 'Keep the most important content in view (player default)' },
-			{ name: 'Fill', value: 'fill', description: 'Cover the frame, cropping as needed' },
-			{ name: 'Pad', value: 'pad', description: 'Fit the whole video within the frame and add padding' },
-		],
-		default: 'smart',
-		description: 'How the player resizes the video to the chosen Aspect Ratio. Only relevant when Aspect Ratio is set (applies to progressive delivery, not adaptive streaming). If your Transformation already crops the video to a shape, applying an Aspect Ratio here crops it a second time — leave Aspect Ratio unset to keep just your transformation\'s framing. See https://cloudinary.com/documentation/video_player_customization.',
-		displayOptions: {
-			show: { resource: ['widget'], operation: ['videoPlayer'], playerAspectRatio: ['1:1', '16:9', '9:16'] },
-		},
-	},
-	{
-		displayName: 'Skin',
-		name: 'playerSkin',
-		type: 'options',
-		options: [
-			{ name: 'Dark', value: 'dark' },
-			{ name: 'Light', value: 'light' },
-		],
-		default: 'dark',
-		description: 'Player theme',
-		displayOptions: {
-			show: { resource: ['widget'], operation: ['videoPlayer'] },
-		},
-	},
-	{
-		displayName: 'Base Color',
-		name: 'playerBaseColor',
-		type: 'color',
-		default: '',
-		description: 'Player base (background) color, as a hex value',
-		displayOptions: {
-			show: { resource: ['widget'], operation: ['videoPlayer'] },
-		},
-	},
-	{
-		displayName: 'Accent Color',
-		name: 'playerAccentColor',
-		type: 'color',
-		default: '',
-		description: 'Player accent (highlight) color, as a hex value',
-		displayOptions: {
-			show: { resource: ['widget'], operation: ['videoPlayer'] },
-		},
-	},
-	{
-		displayName: 'Text Color',
-		name: 'playerTextColor',
-		type: 'color',
-		default: '',
-		description: 'Player text color, as a hex value',
-		displayOptions: {
-			show: { resource: ['widget'], operation: ['videoPlayer'] },
-		},
-	},
-	{
-		displayName: 'Font Face',
-		name: 'playerFontFace',
-		type: 'string',
-		default: '',
-		description: 'The font applied to player text elements (titles, descriptions, recommendations, time counter). Accepts a Google Font name.',
-		displayOptions: {
-			show: { resource: ['widget'], operation: ['videoPlayer'] },
-		},
-	},
-	{
-		displayName: 'Advanced Player Options',
-		name: 'playerAdvancedOptions',
+		displayName: 'Playback',
+		name: 'playerPlayback',
 		type: 'collection',
 		placeholder: 'Add Option',
 		default: {},
-		displayOptions: {
-			show: { resource: ['widget'], operation: ['videoPlayer'] },
-		},
+		description: 'How and when the video plays',
+		displayOptions: SHOW,
+		// Ordered by relevance (autoplay/sound/loop first), not alphabetically.
+		// eslint-disable-next-line n8n-nodes-base/node-param-collection-type-unsorted-items
 		options: [
+			{
+				displayName: 'Autoplay Mode',
+				name: 'autoplayMode',
+				type: 'options',
+				options: [
+					{ name: 'Never', value: '', description: 'Do not autoplay (player default)' },
+					{ name: 'Always', value: 'always', description: 'Autoplay as soon as the player loads' },
+					{ name: 'On Scroll', value: 'on-scroll', description: 'Autoplay when the player scrolls into view' },
+				],
+				default: '',
+				description: 'When the video should start playing automatically. Most browsers require the player to be muted for autoplay to work.',
+			},
+			{
+				displayName: 'Muted',
+				name: 'muted',
+				type: 'boolean',
+				default: false,
+				description: 'Whether the player starts muted',
+			},
+			{
+				displayName: 'Loop',
+				name: 'loop',
+				type: 'boolean',
+				default: false,
+				description: 'Whether the video restarts from the beginning when it ends',
+			},
+			{
+				displayName: 'Plays Inline',
+				name: 'playsinline',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to prevent the player from entering fullscreen automatically on iOS when playback starts',
+			},
+			{
+				displayName: 'Show Controls',
+				name: 'controls',
+				type: 'boolean',
+				default: true,
+				description: 'Whether to show the built-in playback controls (play, pause, volume, fullscreen, etc.)',
+			},
 			{
 				displayName: 'Big Play Button',
 				name: 'bigPlayButton',
@@ -213,13 +111,214 @@ export const widgetFields: INodeProperties[] = [
 				default: true,
 				description: 'Whether to show a larger central play button when the video is paused',
 			},
+		],
+	},
+
+	// ── Size & Layout ───────────────────────────────────────────────────────────
+	{
+		displayName: 'Size & Layout',
+		name: 'playerLayout',
+		type: 'collection',
+		placeholder: 'Add Option',
+		default: {},
+		description: 'The player\'s dimensions and shape',
+		displayOptions: SHOW,
+		// Ordered Fluid → Width/Height → Aspect Ratio → Crop Mode so the dependent
+		// fields read top-down; not alphabetized.
+		// eslint-disable-next-line n8n-nodes-base/node-param-collection-type-unsorted-items
+		options: [
 			{
-				displayName: 'Chapters Button',
-				name: 'chaptersButton',
+				displayName: 'Fluid',
+				name: 'fluid',
 				type: 'boolean',
 				default: false,
-				description: 'Whether to show the chapters button, which opens a list of chapters',
+				description: 'Whether the player resizes responsively to fill its container. When on, Width and Height are replaced by an aspect-ratio CSS style.',
 			},
+			{
+				displayName: 'Width',
+				name: 'width',
+				type: 'number',
+				default: 0,
+				description: 'Player width in pixels. Leave 0 for the default (640 px).',
+				displayOptions: { show: { fluid: [false] } },
+			},
+			{
+				displayName: 'Height',
+				name: 'height',
+				type: 'number',
+				default: 0,
+				description: 'Player height in pixels. Leave 0 for the default (360 px).',
+				displayOptions: { show: { fluid: [false] } },
+			},
+			{
+				displayName: 'Aspect Ratio',
+				name: 'aspectRatio',
+				type: 'options',
+				options: [
+					{ name: '1:1', value: '1:1' },
+					{ name: '16:9', value: '16:9' },
+					{ name: '9:16', value: '9:16' },
+					{ name: 'Default', value: '' },
+				],
+				default: '',
+				description: 'Player aspect ratio. Leave unset to use the video\'s natural dimensions.',
+			},
+			{
+				displayName: 'Crop Mode',
+				name: 'cropMode',
+				type: 'options',
+				options: [
+					{ name: 'Smart', value: 'smart', description: 'Keep the most important content in view (player default)' },
+					{ name: 'Fill', value: 'fill', description: 'Cover the frame, cropping as needed' },
+					{ name: 'Pad', value: 'pad', description: 'Fit the whole video within the frame and add padding' },
+				],
+				default: 'smart',
+				description: 'How the player resizes the video to the chosen Aspect Ratio. Only relevant when Aspect Ratio is set (applies to progressive delivery, not adaptive streaming). If your Transformation already crops the video to a shape, applying an Aspect Ratio here crops it a second time — leave Aspect Ratio unset to keep just your transformation\'s framing. See https://cloudinary.com/documentation/video_player_customization.',
+				displayOptions: { show: { aspectRatio: ['1:1', '16:9', '9:16'] } },
+			},
+		],
+	},
+
+	// ── AI-Generated Content (the flagship capability) ───────────────────────────
+	{
+		displayName: 'AI-Generated Content',
+		name: 'playerAiOptions',
+		type: 'collection',
+		placeholder: 'Add Option',
+		default: {},
+		description:
+			'Have the Cloudinary Video Player generate captions, a title, a description, and chapter markers from the video using AI — no files to author. Generation happens the first time the content is requested in the browser, only for content that does not already exist, and the result is cached. It requires the video audio to contain dialogue. These options affect the generated player config, not the preview embed URL. Learn more: https://cloudinary.com/documentation/video_player_customization.',
+		displayOptions: SHOW,
+		// Ordered for readability, not alphabetized: the captions toggle leads, with its
+		// dependent Label and translation Languages grouped right under it, then the
+		// title/description toggles, then chapters + its dependent button.
+		// eslint-disable-next-line n8n-nodes-base/node-param-collection-type-unsorted-items
+		options: [
+			{
+				displayName: 'Generate Captions',
+				name: 'generateCaptions',
+				type: 'boolean',
+				default: false,
+				description:
+					'Whether to auto-generate captions from the spoken audio, shown as a track the viewer can toggle on or off. The captions are in the video\'s original spoken language — to also offer captions translated into other languages, use Subtitle Languages below.',
+			},
+			{
+				displayName: 'Captions Label',
+				name: 'captionsLabel',
+				type: 'string',
+				default: 'English (auto)',
+				description:
+					'The name shown for the auto-generated captions track in the player\'s captions menu. Set this to match the video\'s spoken language (e.g. "English", "Español").',
+				displayOptions: { show: { generateCaptions: [true] } },
+			},
+			{
+				displayName: 'Subtitle Languages',
+				name: 'subtitleLanguages',
+				type: 'string',
+				default: '',
+				placeholder: 'e.g. es, fr-FR, de',
+				description:
+					'Optional. Leave empty for captions in the original language only. To also offer the captions translated into other languages, enter target language codes separated by commas — each adds a translated subtitle track the viewer can pick. Translation requires the Google Translate add-on on your account (register at https://console.cloudinary.com/settings/addons, then enable it under Settings → Security → Unsigned add-on transformations). Captions in the original language need no add-on.',
+				displayOptions: { show: { generateCaptions: [true] } },
+			},
+			{
+				displayName: 'Generate Title',
+				name: 'generateTitle',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to show an AI-generated title for the video in the player',
+			},
+			{
+				displayName: 'Generate Description',
+				name: 'generateDescription',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to show an AI-generated description for the video in the player',
+			},
+			{
+				displayName: 'Generate Chapters',
+				name: 'generateChapters',
+				type: 'boolean',
+				default: false,
+				description:
+					'Whether to auto-generate chapter markers so viewers can jump between sections of the video',
+			},
+			{
+				displayName: 'Show Chapters Button',
+				name: 'chaptersButton',
+				type: 'boolean',
+				default: true,
+				description:
+					'Whether to show the chapters button in the player, which opens the list of chapters so viewers can navigate. Shown only when Generate Chapters is on; turn off to keep the chapters available without surfacing the button.',
+				displayOptions: { show: { generateChapters: [true] } },
+			},
+		],
+	},
+
+	// ── Appearance ────────────────────────────────────────────────────────────
+	{
+		displayName: 'Appearance',
+		name: 'playerAppearance',
+		type: 'collection',
+		placeholder: 'Add Option',
+		default: {},
+		description: 'The player\'s theme, colors, and font',
+		displayOptions: SHOW,
+		// Skin first (it sets the baseline), then the color/font overrides; not alphabetized.
+		// eslint-disable-next-line n8n-nodes-base/node-param-collection-type-unsorted-items
+		options: [
+			{
+				displayName: 'Skin',
+				name: 'skin',
+				type: 'options',
+				options: [
+					{ name: 'Dark', value: 'dark' },
+					{ name: 'Light', value: 'light' },
+				],
+				default: 'dark',
+				description: 'Player theme',
+			},
+			{
+				displayName: 'Base Color',
+				name: 'baseColor',
+				type: 'color',
+				default: '',
+				description: 'Player base (background) color, as a hex value',
+			},
+			{
+				displayName: 'Accent Color',
+				name: 'accentColor',
+				type: 'color',
+				default: '',
+				description: 'Player accent (highlight) color, as a hex value',
+			},
+			{
+				displayName: 'Text Color',
+				name: 'textColor',
+				type: 'color',
+				default: '',
+				description: 'Player text color, as a hex value',
+			},
+			{
+				displayName: 'Font Face',
+				name: 'fontFace',
+				type: 'string',
+				default: '',
+				description: 'The font applied to player text elements (titles, descriptions, recommendations, time counter). Accepts a Google Font name.',
+			},
+		],
+	},
+
+	// ── Player Features (niche UI toggles) ───────────────────────────────────────
+	{
+		displayName: 'Player Features',
+		name: 'playerFeatures',
+		type: 'collection',
+		placeholder: 'Add Option',
+		default: {},
+		description: 'Optional interface controls and capabilities to switch on',
+		displayOptions: SHOW,
+		options: [
 			{
 				displayName: 'Floating When Not Visible',
 				name: 'floatingWhenNotVisible',
@@ -247,25 +346,11 @@ export const widgetFields: INodeProperties[] = [
 				description: 'Whether to show the picture-in-picture toggle, letting users view the video in a floating window',
 			},
 			{
-				displayName: 'Plays Inline',
-				name: 'playsinline',
-				type: 'boolean',
-				default: false,
-				description: 'Whether to prevent the player from entering fullscreen automatically on iOS when playback starts',
-			},
-			{
 				displayName: 'Seek Thumbnails',
 				name: 'seekThumbnails',
 				type: 'boolean',
 				default: true,
 				description: 'Whether to show thumbnail previews when seeking with the seek bar',
-			},
-			{
-				displayName: 'Show Controls',
-				name: 'controls',
-				type: 'boolean',
-				default: true,
-				description: 'Whether to show the built-in playback controls (play, pause, volume, fullscreen, etc.)',
 			},
 		],
 	},

--- a/nodes/Cloudinary/operations/widget/videoPlayer.ts
+++ b/nodes/Cloudinary/operations/widget/videoPlayer.ts
@@ -38,30 +38,57 @@ interface PlayerParams {
 	textColor: string;
 	fontFace: string;
 	advanced: IDataObject;
+	ai: IDataObject;
 }
 
 export const videoPlayer: OperationHandler = async (ctx, i, creds) => {
 	const { publicId, deliveryType } = readTransformInput(ctx, i);
+
+	// Controls are grouped into purpose-named collections in the UI (see widget.fields.ts).
+	// Read each collection once, then pull values with defaults. `playback` and `features`
+	// are merged into a single `advanced` bag because buildEmbedUrl/buildPlayerConfig key
+	// off the same toggle names regardless of which UI group they now live in.
+	const playback = ctx.getNodeParameter('playerPlayback', i, {}) as IDataObject;
+	const layout = ctx.getNodeParameter('playerLayout', i, {}) as IDataObject;
+	const appearance = ctx.getNodeParameter('playerAppearance', i, {}) as IDataObject;
+	const features = ctx.getNodeParameter('playerFeatures', i, {}) as IDataObject;
+	const ai = ctx.getNodeParameter('playerAiOptions', i, {}) as IDataObject;
+	const num = (v: unknown, d: number): number => (v === undefined ? d : Number(v) || 0);
+
 	const p: PlayerParams = {
 		publicId,
 		deliveryType,
-		autoplayMode: ctx.getNodeParameter('playerAutoplayMode', i, '') as string,
-		loop: ctx.getNodeParameter('playerLoop', i, false) as boolean,
-		muted: ctx.getNodeParameter('playerMuted', i, false) as boolean,
+		autoplayMode: (playback.autoplayMode as string) ?? '',
+		loop: (playback.loop as boolean) ?? false,
+		muted: (playback.muted as boolean) ?? false,
 		sourceTypes: ctx.getNodeParameter('playerSourceTypes', i, []) as string[],
 		poster: ctx.getNodeParameter('playerPoster', i, '') as string,
 		transformation: ctx.getNodeParameter('playerTransformation', i, '') as string,
-		fluid: ctx.getNodeParameter('playerFluid', i, false) as boolean,
-		width: ctx.getNodeParameter('playerWidth', i, 0) as number,
-		height: ctx.getNodeParameter('playerHeight', i, 0) as number,
-		aspectRatio: ctx.getNodeParameter('playerAspectRatio', i, '') as string,
-		cropMode: ctx.getNodeParameter('playerCropMode', i, 'smart') as string,
-		skin: ctx.getNodeParameter('playerSkin', i, 'dark') as string,
-		baseColor: ctx.getNodeParameter('playerBaseColor', i, '') as string,
-		accentColor: ctx.getNodeParameter('playerAccentColor', i, '') as string,
-		textColor: ctx.getNodeParameter('playerTextColor', i, '') as string,
-		fontFace: ctx.getNodeParameter('playerFontFace', i, '') as string,
-		advanced: ctx.getNodeParameter('playerAdvancedOptions', i, {}) as IDataObject,
+		fluid: (layout.fluid as boolean) ?? false,
+		width: num(layout.width, 0),
+		height: num(layout.height, 0),
+		aspectRatio: (layout.aspectRatio as string) ?? '',
+		cropMode: (layout.cropMode as string) ?? 'smart',
+		skin: (appearance.skin as string) ?? 'dark',
+		baseColor: (appearance.baseColor as string) ?? '',
+		accentColor: (appearance.accentColor as string) ?? '',
+		textColor: (appearance.textColor as string) ?? '',
+		fontFace: (appearance.fontFace as string) ?? '',
+		// buildEmbedUrl/buildPlayerConfig read controls/playsinline/bigPlayButton (Playback)
+		// alongside pictureInPictureToggle/seekThumbnails/hdr/floating (Features). The chapters
+		// button lives in the AI group (gated on Generate Chapters) since it has no purpose
+		// without a chapters source, so it's read from `ai` below.
+		advanced: {
+			controls: playback.controls,
+			playsinline: playback.playsinline,
+			bigPlayButton: playback.bigPlayButton,
+			pictureInPictureToggle: features.pictureInPictureToggle,
+			chaptersButton: ai.generateChapters ? ai.chaptersButton : undefined,
+			seekThumbnails: features.seekThumbnails,
+			hdr: features.hdr,
+			floatingWhenNotVisible: features.floatingWhenNotVisible,
+		},
+		ai,
 	};
 
 	// Fail fast on the streaming-profile vs format-selection conflict: an HLS/DASH source
@@ -200,6 +227,30 @@ function buildPlayerConfig(cloudName: string, p: PlayerParams): IDataObject {
 	if (adv.hdr) cfg.hdr = true;
 	if (adv.floatingWhenNotVisible && adv.floatingWhenNotVisible !== 'disabled') {
 		cfg.floatingWhenNotVisible = adv.floatingWhenNotVisible;
+	}
+
+	// On-demand AI generation — emitted into player_config only (these are JS player.source()
+	// options, not iframe URL params). The player generates each only if it doesn't already
+	// exist, returning a 202 while it works. See the customization docs.
+	const ai = p.ai;
+	if (ai.generateTitle) cfg.title = true;
+	if (ai.generateDescription) cfg.description = true;
+	if (ai.generateChapters) cfg.chapters = true;
+	if (ai.generateCaptions) {
+		const textTracks: IDataObject = {
+			// No `url` → the player auto-generates the transcript for captions.
+			captions: { label: String(ai.captionsLabel || 'English (auto)'), default: true },
+		};
+		// Each language code becomes an auto-translated subtitle track (no `url`). Translation
+		// requires the Google Translate add-on — see the field description and docs.
+		const langs = String(ai.subtitleLanguages || '')
+			.split(',')
+			.map((l) => l.trim())
+			.filter(Boolean);
+		if (langs.length) {
+			textTracks.subtitles = langs.map((language) => ({ label: language, language }));
+		}
+		cfg.textTracks = textTracks;
 	}
 
 	return cfg;

--- a/nodes/Cloudinary/operations/widget/widget.test.ts
+++ b/nodes/Cloudinary/operations/widget/widget.test.ts
@@ -21,19 +21,19 @@ describe('widget:videoPlayer', () => {
 	});
 
 	it('includes autoplayMode in embed_url when set', async () => {
-		const { ctx } = makeCtx({ params: { transformPublicId: 'v', playerAutoplayMode: 'always' } });
+		const { ctx } = makeCtx({ params: { transformPublicId: 'v', playerPlayback: { autoplayMode: 'always' } } });
 		const [out] = await videoPlayer(ctx, 0, testCreds);
 		expect(out.embed_url).toContain('player[autoplayMode]=always');
 	});
 
 	it('omits autoplayMode from embed_url when blank', async () => {
-		const { ctx } = makeCtx({ params: { transformPublicId: 'v', playerAutoplayMode: '' } });
+		const { ctx } = makeCtx({ params: { transformPublicId: 'v', playerPlayback: { autoplayMode: '' } } });
 		const [out] = await videoPlayer(ctx, 0, testCreds);
 		expect(out.embed_url).not.toContain('player[autoplayMode]');
 	});
 
 	it('includes muted and loop flags in embed_url', async () => {
-		const { ctx } = makeCtx({ params: { transformPublicId: 'v', playerMuted: true, playerLoop: true } });
+		const { ctx } = makeCtx({ params: { transformPublicId: 'v', playerPlayback: { muted: true, loop: true } } });
 		const [out] = await videoPlayer(ctx, 0, testCreds);
 		expect(out.embed_url).toContain('player[muted]=true');
 		expect(out.embed_url).toContain('player[loop]=true');
@@ -50,9 +50,7 @@ describe('widget:videoPlayer', () => {
 		const { ctx } = makeCtx({
 			params: {
 				transformPublicId: 'v',
-				playerBaseColor: '#0071ba',
-				playerAccentColor: '#db8226',
-				playerTextColor: '#ffffff',
+				playerAppearance: { baseColor: '#0071ba', accentColor: '#db8226', textColor: '#ffffff' },
 			},
 		});
 		const [out] = await videoPlayer(ctx, 0, testCreds);
@@ -139,23 +137,23 @@ describe('widget:videoPlayer', () => {
 	});
 
 	it('includes player[skin]=light for light skin, omits for default dark', async () => {
-		const { ctx: ctxLight } = makeCtx({ params: { transformPublicId: 'v', playerSkin: 'light' } });
+		const { ctx: ctxLight } = makeCtx({ params: { transformPublicId: 'v', playerAppearance: { skin: 'light' } } });
 		const [outLight] = await videoPlayer(ctxLight, 0, testCreds);
 		expect(outLight.embed_url).toContain('player[skin]=light');
 
-		const { ctx: ctxDark } = makeCtx({ params: { transformPublicId: 'v', playerSkin: 'dark' } });
+		const { ctx: ctxDark } = makeCtx({ params: { transformPublicId: 'v', playerAppearance: { skin: 'dark' } } });
 		const [outDark] = await videoPlayer(ctxDark, 0, testCreds);
 		expect(outDark.embed_url).not.toContain('player[skin]');
 	});
 
 	it('includes player[fluid]=true when playerFluid is true', async () => {
-		const { ctx } = makeCtx({ params: { transformPublicId: 'v', playerFluid: true } });
+		const { ctx } = makeCtx({ params: { transformPublicId: 'v', playerLayout: { fluid: true } } });
 		const [out] = await videoPlayer(ctx, 0, testCreds);
 		expect(out.embed_url).toContain('player[fluid]=true');
 	});
 
 	it('includes aspect ratio in embed_url, URL-encoded', async () => {
-		const { ctx } = makeCtx({ params: { transformPublicId: 'v', playerFluid: true, playerAspectRatio: '9:16' } });
+		const { ctx } = makeCtx({ params: { transformPublicId: 'v', playerLayout: { fluid: true, aspectRatio: '9:16' } } });
 		const [out] = await videoPlayer(ctx, 0, testCreds);
 		expect(out.embed_url).toContain('player[aspectRatio]=9%3A16');
 	});
@@ -166,7 +164,7 @@ describe('widget:videoPlayer', () => {
 		const { ctx } = makeCtx({
 			params: {
 				transformPublicId: 'samples/elephants',
-				playerAspectRatio: '9:16',
+				playerLayout: { aspectRatio: '9:16' },
 				playerTransformation: 'f_auto:video/q_auto/so_5,eo_30',
 			},
 		});
@@ -177,8 +175,7 @@ describe('widget:videoPlayer', () => {
 		const { ctx } = makeCtx({
 			params: {
 				transformPublicId: 'v',
-				playerAspectRatio: '9:16',
-				playerCropMode: 'fill',
+				playerLayout: { aspectRatio: '9:16', cropMode: 'fill' },
 				playerTransformation: 'f_auto:video/q_auto/so_5,eo_30',
 			},
 		});
@@ -187,7 +184,7 @@ describe('widget:videoPlayer', () => {
 	});
 
 	it('does not throw for an aspect ratio with no transformation (smart crop alone is fine)', async () => {
-		const { ctx } = makeCtx({ params: { transformPublicId: 'v', playerAspectRatio: '9:16' } });
+		const { ctx } = makeCtx({ params: { transformPublicId: 'v', playerLayout: { aspectRatio: '9:16' } } });
 		const [out] = await videoPlayer(ctx, 0, testCreds);
 		expect(out.embed_url).toContain('player[aspectRatio]=9%3A16');
 	});
@@ -202,7 +199,7 @@ describe('widget:videoPlayer', () => {
 
 	it('includes source[cropMode] in embed_url for a non-default mode with an aspect ratio', async () => {
 		const { ctx } = makeCtx({
-			params: { transformPublicId: 'v', playerAspectRatio: '16:9', playerCropMode: 'fill' },
+			params: { transformPublicId: 'v', playerLayout: { aspectRatio: '16:9', cropMode: 'fill' } },
 		});
 		const [out] = await videoPlayer(ctx, 0, testCreds);
 		expect(out.embed_url).toContain('source[cropMode]=fill');
@@ -212,7 +209,7 @@ describe('widget:videoPlayer', () => {
 
 	it('omits cropMode when it is the default smart mode', async () => {
 		const { ctx } = makeCtx({
-			params: { transformPublicId: 'v', playerAspectRatio: '16:9', playerCropMode: 'smart' },
+			params: { transformPublicId: 'v', playerLayout: { aspectRatio: '16:9', cropMode: 'smart' } },
 		});
 		const [out] = await videoPlayer(ctx, 0, testCreds);
 		expect(out.embed_url).not.toContain('cropMode');
@@ -223,7 +220,7 @@ describe('widget:videoPlayer', () => {
 	it('omits cropMode when no aspect ratio is set, even if a mode is chosen', async () => {
 		// cropMode only takes effect alongside aspectRatio, so it would be inert without one.
 		const { ctx } = makeCtx({
-			params: { transformPublicId: 'v', playerAspectRatio: '', playerCropMode: 'pad' },
+			params: { transformPublicId: 'v', playerLayout: { aspectRatio: '', cropMode: 'pad' } },
 		});
 		const [out] = await videoPlayer(ctx, 0, testCreds);
 		expect(out.embed_url).not.toContain('cropMode');
@@ -232,7 +229,7 @@ describe('widget:videoPlayer', () => {
 	});
 
 	it('includes width and height in embed_url', async () => {
-		const { ctx } = makeCtx({ params: { transformPublicId: 'v', playerWidth: 800, playerHeight: 450 } });
+		const { ctx } = makeCtx({ params: { transformPublicId: 'v', playerLayout: { width: 800, height: 450 } } });
 		const [out] = await videoPlayer(ctx, 0, testCreds);
 		expect(out.embed_url).toContain('player[width]=800');
 		expect(out.embed_url).toContain('player[height]=450');
@@ -248,16 +245,16 @@ describe('widget:videoPlayer', () => {
 
 	it('player_config includes colors object for set color fields', async () => {
 		const { ctx } = makeCtx({
-			params: { transformPublicId: 'v', playerBaseColor: '#0071ba', playerAccentColor: '#db8226' },
+			params: { transformPublicId: 'v', playerAppearance: { baseColor: '#0071ba', accentColor: '#db8226' } },
 		});
 		const [out] = await videoPlayer(ctx, 0, testCreds);
 		const cfg = JSON.parse(out.player_config as string);
 		expect(cfg.colors).toEqual({ base: '#0071ba', accent: '#db8226' });
 	});
 
-	it('includes advanced controls=false in embed_url and player_config', async () => {
+	it('includes controls=false (Playback) in embed_url and player_config', async () => {
 		const { ctx } = makeCtx({
-			params: { transformPublicId: 'v', playerAdvancedOptions: { controls: false } },
+			params: { transformPublicId: 'v', playerPlayback: { controls: false } },
 		});
 		const [out] = await videoPlayer(ctx, 0, testCreds);
 		expect(out.embed_url).toContain('player[controls]=false');
@@ -286,5 +283,101 @@ describe('widget:videoPlayer', () => {
 		const { ctx } = makeCtx({ params: { transformPublicId: 'v', playerPoster: '' } });
 		const [out] = await videoPlayer(ctx, 0, testCreds);
 		expect(out.embed_url).not.toContain('source[poster]');
+	});
+
+	// ── AI-generated content (player_config only; never embed-URL params) ──────────
+	it('emits AI captions as a textTracks.captions entry with no url', async () => {
+		const { ctx } = makeCtx({
+			params: { transformPublicId: 'v', playerAiOptions: { generateCaptions: true } },
+		});
+		const [out] = await videoPlayer(ctx, 0, testCreds);
+		const cfg = JSON.parse(out.player_config as string);
+		expect(cfg.textTracks.captions).toEqual({ label: 'English (auto)', default: true });
+		expect(cfg.textTracks.captions.url).toBeUndefined();
+		// AI options are JS-config-only and must never leak into the embed URL.
+		expect(out.embed_url).not.toContain('textTracks');
+	});
+
+	it('uses a custom captions label when provided', async () => {
+		const { ctx } = makeCtx({
+			params: {
+				transformPublicId: 'v',
+				playerAiOptions: { generateCaptions: true, captionsLabel: 'EN' },
+			},
+		});
+		const [out] = await videoPlayer(ctx, 0, testCreds);
+		const cfg = JSON.parse(out.player_config as string);
+		expect(cfg.textTracks.captions.label).toBe('EN');
+	});
+
+	it('emits translated subtitle tracks for comma-separated language codes', async () => {
+		const { ctx } = makeCtx({
+			params: {
+				transformPublicId: 'v',
+				playerAiOptions: { generateCaptions: true, subtitleLanguages: 'es, fr-FR' },
+			},
+		});
+		const [out] = await videoPlayer(ctx, 0, testCreds);
+		const cfg = JSON.parse(out.player_config as string);
+		expect(cfg.textTracks.subtitles).toEqual([
+			{ label: 'es', language: 'es' },
+			{ label: 'fr-FR', language: 'fr-FR' },
+		]);
+	});
+
+	it('omits subtitles when no languages are given', async () => {
+		const { ctx } = makeCtx({
+			params: { transformPublicId: 'v', playerAiOptions: { generateCaptions: true } },
+		});
+		const [out] = await videoPlayer(ctx, 0, testCreds);
+		const cfg = JSON.parse(out.player_config as string);
+		expect(cfg.textTracks.subtitles).toBeUndefined();
+	});
+
+	it('emits title, description, and chapters flags when enabled', async () => {
+		const { ctx } = makeCtx({
+			params: {
+				transformPublicId: 'v',
+				playerAiOptions: { generateTitle: true, generateDescription: true, generateChapters: true },
+			},
+		});
+		const [out] = await videoPlayer(ctx, 0, testCreds);
+		const cfg = JSON.parse(out.player_config as string);
+		expect(cfg.title).toBe(true);
+		expect(cfg.description).toBe(true);
+		expect(cfg.chapters).toBe(true);
+	});
+
+	it('emits no AI keys when the AI options are left empty', async () => {
+		const { ctx } = makeCtx({ params: { transformPublicId: 'v' } });
+		const [out] = await videoPlayer(ctx, 0, testCreds);
+		const cfg = JSON.parse(out.player_config as string);
+		expect(cfg.textTracks).toBeUndefined();
+		expect(cfg.title).toBeUndefined();
+		expect(cfg.description).toBeUndefined();
+		expect(cfg.chapters).toBeUndefined();
+		expect(cfg.chaptersButton).toBeUndefined();
+	});
+
+	it('shows the chapters button when chapters are generated (default on)', async () => {
+		const { ctx } = makeCtx({
+			params: { transformPublicId: 'v', playerAiOptions: { generateChapters: true, chaptersButton: true } },
+		});
+		const [out] = await videoPlayer(ctx, 0, testCreds);
+		const cfg = JSON.parse(out.player_config as string);
+		expect(cfg.chapters).toBe(true);
+		expect(cfg.chaptersButton).toBe(true);
+	});
+
+	it('does not emit the chapters button without generated chapters', async () => {
+		// The button is gated on Generate Chapters in the UI; the handler also guards it,
+		// so a stray chaptersButton can't surface a button with no chapters source.
+		const { ctx } = makeCtx({
+			params: { transformPublicId: 'v', playerAiOptions: { chaptersButton: true } },
+		});
+		const [out] = await videoPlayer(ctx, 0, testCreds);
+		const cfg = JSON.parse(out.player_config as string);
+		expect(cfg.chapters).toBeUndefined();
+		expect(cfg.chaptersButton).toBeUndefined();
 	});
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-cloudinary",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "The official Cloudinary n8n node - upload media, update asset tags and metadata, and more",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary

Two changes to the **Widget → Video Player** operation:

1. **New AI-Generated Content options** — drive the player's on-demand AI generation, so users get captions, transcripts, title/description, and chapters with no files to author.
2. **Regrouped the Video Player UI** — the 19 controls are no longer a flat wall; "Advanced Player Options" is gone, replaced by purpose-named collapsible groups with the source essentials kept top-level.

## AI-Generated Content

A new collapsible section on the node:

- **Generate Captions** — auto-generates a transcript shown as a toggleable captions track, in the video's original spoken language.
- **Subtitle Languages** — *optional*, comma-separated target language codes for AI-**translated** subtitle tracks. Empty by default.
- **Generate Title / Description / Chapters** — AI-generated metadata + chapter markers. The **chapters button** is grouped under (and gated on) *Generate Chapters*, so it can never surface a button with no chapters source.

These are emitted into `player_config` (the JS `player.source()` config), not the iframe embed URL — matching how the player exposes them.

### Out-of-the-box safety
- The collection defaults to `{}` — with nothing added, the node emits **zero** AI keys and behaves exactly as before. Fully opt-in.
- Captions/title/description/chapters are **unsigned actions enabled by default** on most accounts → work with no setup.
- The only add-on-gated feature (translated subtitles) is **never triggered by default**: `Subtitle Languages` is empty, so a user must deliberately enter codes. The README documents a Google Translate add-on setup CTA for when they do.

## New Video Player layout

```
VIDEO PLAYER
├─ Public ID · Type · Transformation · Poster · Source Types   (top-level essentials)
├─ ▸ Playback           Autoplay · Muted · Loop · Plays Inline · Show Controls · Big Play Button
├─ ▸ Size & Layout      Fluid · Width · Height · Aspect Ratio · Crop Mode
├─ ▸ AI-Generated Content   Captions (+Label, Languages) · Title · Description · Chapters (+Button)
├─ ▸ Appearance         Skin · Base/Accent/Text Color · Font Face
└─ ▸ Player Features     Floating · HDR · Picture-in-Picture · Seek Thumbnails
```

Also in this PR:
- **Poster** promoted to a top-level source essential (it's about the source, like Transformation — not playback or chrome).
- **Source Types** description rewritten to lead with plain meaning + an HLS/MP4 fallback tip, keeping the format-pin caveat. Name kept to mirror the Cloudinary API's `sourceTypes` property.
- **README** documents the AI options + the Google Translate add-on enable steps.

## Backward compatibility

⚠️ **This relies on `0.0.9` being the currently active (latest published) npm version.**

The only version ever published to npm is **`0.0.9`, which has no Video Player operation at all**. Regrouping these fields into collections renames their parameter keys — but since no released version ever exposed Video Player fields, **no saved workflow can reference them**, so nothing breaks.

The `backward-compatibility-check` reports **0 breaking changes** against the `0.0.9` baseline; every new/moved param registers as additive.

> This holds only while `0.0.9` is the latest published version. Once a release that ships the *flat* Video Player fields goes out, any further regrouping would require a `typeVersion` bump.

Bumps version to **`0.2.0`** (additive feature).

## Testing
- `npm test` — **234 tests pass** (widget suite extended for the new AI fields, the nested-collection reads, and the chapters-button gating).
- `tsc --noEmit`, `eslint`, `npm run build` — clean.
- `npm run backward-compatibility-check` — 0 breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
